### PR TITLE
Add notification schema

### DIFF
--- a/examples/subscriptions-vdc-misconfiguration.json
+++ b/examples/subscriptions-vdc-misconfiguration.json
@@ -8,5 +8,14 @@
   "time": "2018-04-05T17:31:00Z",
   "redhatorgid": "org123",
   "redhatconsolebundle": "rhel",
-  "dataschema": "https://console.redhat.com/api/schemas/core/v1/empty.json"
+  "dataschema": "https://console.redhat.com/api/schemas/core/v1/notification.json",
+  "data": {
+    "notification_recipients": {
+      "only_admins": true,
+      "ignore_user_preferences": true,
+      "users": [
+        "jane@example.com"
+      ]
+    }
+  }
 }

--- a/schemas/core/v1/notification.json
+++ b/schemas/core/v1/notification.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://console.redhat.com/api/schemas/core/v1/notification.json",
+  "description": "Notification event. Appropriate when an event has no data aside from recipient settings. If the event requires data, then it should reference the Recipient object definition in a separate schema.",
+  "type": "object",
+  "properties": {
+    "notification_recipients": {
+      "$ref": "#/definitions/Recipients"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Recipients": {
+      "description": "Notification recipients. Should be in a top-level field named \"notification_recipients\"",
+      "type": "object",
+      "properties": {
+        "only_admins": {
+          "description": "Setting to true sends an email to the administrators of the account. Setting to false sends an email to all users of the account.",
+          "type": "boolean"
+        },
+        "ignore_user_preferences": {
+          "description": "Setting to true ignores all the user preferences on this Recipient setting (It doesn’t affect other configuration that an Administrator sets on their Notification settings). Setting to false honors the user preferences.",
+          "type": "boolean"
+        },
+        "users": {
+          "description": "List of users to direct the notification to. This won’t override notification's administrators settings. Users list will be merged with other settings.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/events/v1/events.json
+++ b/schemas/events/v1/events.json
@@ -68,6 +68,9 @@
           "$ref": "../../core/v1/error.json"
         },
         {
+          "$ref": "../../core/v1/notification.json"
+        },
+        {
           "$ref": "../../core/v1/rhel_system.json"
         }
       ]
@@ -78,6 +81,14 @@
       "$ref": "#/definitions/timedef",
       "examples": [
         "2018-04-05T17:31:00Z"
+      ]
+    },
+    "redhataccount": {
+      "description": "Red Hat account number. Deprecated; redhatorgid should be used instead.",
+      "deprecated": true,
+      "$ref": "#/definitions/redhataccountdef",
+      "examples": [
+        "123456"
       ]
     },
     "redhatorgid": {
@@ -95,13 +106,16 @@
     "specversion",
     "type",
     "dataschema",
-    "time",
-    "redhatorgid"
+    "time"
   ],
   "definitions": {
     "timedef": {
       "type": "string",
       "format": "date-time",
+      "minLength": 1
+    },
+    "redhataccountdef": {
+      "type": "string",
       "minLength": 1
     },
     "redhatorgiddef": {

--- a/schemas/events/v1/events.json
+++ b/schemas/events/v1/events.json
@@ -106,7 +106,8 @@
     "specversion",
     "type",
     "dataschema",
-    "time"
+    "time",
+    "redhatorgid"
   ],
   "definitions": {
     "timedef": {


### PR DESCRIPTION
Referencing the internal documentation for sending notification messages, I mapped each field to the cloudevents schema:

1. `version`: unneeded assuming we used versioning in the `dataschema` URIs
2. `bundle` -> `redhatconsolebundle`
3. `application` -> `source` URN.
4. `event_type` -> `type`.
5. `timestamp` -> `time`.
6. `account_id` -> `redhataccount` (added as deprecated, with a note to prefer `redhatorgid`)
7. `context` - expected to be incorporated into the event's `dataschema`.
8. `metadata` - expected to be incorporated into the event's `dataschema`
9. `payload` -> `data`
10. `recipients` -> `notification_recipients` defined in `schemas/core/v1/notification.json`.

(11, 12, and 13 are properties of `notification_recipients`).

The expection on apps is that they only actually need to reference and/or use the notification schema if they need to override notification settings. Otherwise, the general events schema captures all needed fields implicitly.

If they need to use the schema, there are two cases:

1. If the event contains no other data, the app should set `dataschema` to `schemas/core/v1/notification.json`.
2. If the event contains other data, the app should use another `dataschema`, and reference `notification_recipients` definition as `"$ref": "../../../core/v1/notification.json#/definitions/Recipients"`