### PR TITLE
Adding title and link to the event schema

### DIFF
--- a/schemas/core/v1/human_readable.json
+++ b/schemas/core/v1/human_readable.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://console.redhat.com/api/schemas/core/v1/human_readable.json",
+  "description": "Schema that indicates information to make it easier for humans to read the message such as names and a link to a webpage",
+  "type": "object",
+  "properties": {
+    "title": {
+      "description": "Human readable text to identify an element.",
+      "type": "string",
+      "examples": [
+        "5 Recommendations for system MySystem",
+        "12 Policies triggered for system MySystem",
+        "Policy 'My new policy' triggered for system MySystem"
+      ]
+    },
+    "href_url": {
+      "description": "Link to human readable content to see information regarding the event.",
+      "type": "string",
+      "format": "uri",
+      "examples": [
+        "http://link-to-system-checkin.com",
+        "http://link-to-policy.com/policy-id"
+      ]
+    }
+  }
+}

--- a/schemas/events/v1/events.json
+++ b/schemas/events/v1/events.json
@@ -72,6 +72,9 @@
         },
         {
           "$ref": "../../core/v1/rhel_system.json"
+        },
+        {
+          "$ref": "../../core/v1/human_readable.json"
         }
       ]
     },


### PR DESCRIPTION
We were discussing today about [NOTIF-538](https://issues.redhat.com/browse/NOTIF-538) which requests a common way to display the event in the UI and link to them.

The proposal is to add the optional fields for `title` which describes the event in a human readable form such as: `10 recomendations found for system ABC`. It will be up to the sender to define a `title`.

Other nice thing to have would be an URI to link back to the event or to see more information, this would be related to the event.

Right now the consumer of the event has to create a title by checking the event type and using the contents of the event to build a meaninful message. 

//cc: @RedHatInsights/notifications-committers 