### PR TITLE
Removes type from `time`

### DIFF
--- a/schemas/events/v1/events.json
+++ b/schemas/events/v1/events.json
@@ -74,7 +74,6 @@
     },
     "time": {
       "description": "Timestamp of when the occurrence happened. Must adhere to RFC 3339.",
-      "type": "string",
       "$ref": "#/definitions/timedef",
       "examples": [
         "2018-04-05T17:31:00Z"


### PR DESCRIPTION
The type is already defined in the `$ref` - having it there confuses some tools such as quicktype