### PR TITLE
fix: Make subject optional

### DIFF
--- a/schemas/events/v1/events.json
+++ b/schemas/events/v1/events.json
@@ -187,7 +187,6 @@
   "required": [
     "id",
     "source",
-    "subject",
     "specversion",
     "type",
     "dataschema",


### PR DESCRIPTION
 Not all the times the subject might be something easy to figure out
 By having it as required we are forcing applications to write something
 here that could be just repeated data not providing any real value.

 We should make it optional and provide some guides showing its
 benefits and how to find what would be the best value in here.

 The official spec has it marked as optional.
 https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/spec.md#subject