### PR TITLE
[RHCLOUD-26048] refactor: update the export service's request

### DIFF
--- a/examples/export-service.json
+++ b/examples/export-service.json
@@ -1,17 +1,18 @@
 {
     "$schema": "https://console.redhat.com/api/schemas/events/v1/events.json",
     "id": "2356aad8-de45-4ba0-80bd-4637763ad115",
-    "source": "urn:redhat:source:console:export-service",
+    "source": "urn:redhat:source:console:app:export-service",
     "specversion": "1.0",
     "type": "com.redhat.console.export-service.request",
-    "subject": "urn:redhat:subject:export-service:b24c269d-33d6-410e-8808-c71c9635e84f",
+    "subject": "urn:redhat:subject:export-service:request:2e3d7746-2cf2-441e-84fe-cf28863d22ae",
     "time": "2023-01-01T00:00:00Z",
     "redhatorgid": "org123",
     "redhatconsolebundle": "rhel",
-    "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/export-request.json",
+    "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
     "data": {
-        "exportRequest": {
-            "uuid": "6aa703bc-5e32-47ea-83ca-335ecea1b085",
+        "resourceRequest": {
+            "uuid": "b24c269d-33d6-410e-8808-c71c9635e84f",
+            "exportRequestUuid": "2e3d7746-2cf2-441e-84fe-cf28863d22ae",
             "application": "myApp",
             "format": "csv",
             "resource": "myResource",
@@ -22,5 +23,5 @@
             }
         }
     }
-  }
+}
   

--- a/examples/export-service.json
+++ b/examples/export-service.json
@@ -10,9 +10,9 @@
     "redhatconsolebundle": "rhel",
     "dataschema": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
     "data": {
-        "resourceRequest": {
+        "resource_request": {
             "uuid": "b24c269d-33d6-410e-8808-c71c9635e84f",
-            "exportRequestUuid": "2e3d7746-2cf2-441e-84fe-cf28863d22ae",
+            "export_request_uuid": "2e3d7746-2cf2-441e-84fe-cf28863d22ae",
             "application": "myApp",
             "format": "csv",
             "resource": "myResource",

--- a/schemas/apps/export-service/v1/resource-request.json
+++ b/schemas/apps/export-service/v1/resource-request.json
@@ -5,14 +5,14 @@
   "title": "ExportServiceEventData",
   "type": "object",
   "properties": {
-    "resourceRequest": {
+    "resource_request": {
       "description": "A request for data to be exported",
       "type": "object",
       "$ref": "#/definitions/ResourceRequest"
     }
   },
   "required": [
-    "resourceRequest"
+    "resource_request"
   ],
   "additionalProperties": false,
   "definitions": {
@@ -25,7 +25,7 @@
           "type": "string",
           "format": "uuid"
         },
-        "exportRequestUuid": {
+        "export_request_uuid": {
           "description": "The unique identifier of the export request that triggered the resource request",
           "type": "string",
           "format": "uuid"
@@ -58,7 +58,7 @@
       },
       "required": [
         "uuid",
-        "exportRequestUuid",
+        "export_request_uuid",
         "application",
         "format",
         "resource",

--- a/schemas/apps/export-service/v1/resource-request.json
+++ b/schemas/apps/export-service/v1/resource-request.json
@@ -1,27 +1,32 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://console.redhat.com/api/schemas/apps/export-service/v1/export-request.json",
-  "description": "Event data for data export requests.",
+  "$id": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json",
+  "description": "Event data for data export requests",
   "title": "ExportServiceEventData",
   "type": "object",
   "properties": {
-    "exportRequest": {
+    "resourceRequest": {
       "description": "A request for data to be exported",
       "type": "object",
-      "$ref": "#/definitions/ExportRequest"
+      "$ref": "#/definitions/ResourceRequest"
     }
   },
   "required": [
-    "exportRequest"
+    "resourceRequest"
   ],
   "additionalProperties": false,
   "definitions": {
-    "ExportRequest": {
+    "ResourceRequest": {
       "description": "A request for data to be exported",
       "type": "object",
       "properties": {
         "uuid": {
-          "description": "A unique identifier for the request",
+          "description": "A unique identifier for the resource request",
+          "type": "string",
+          "format": "uuid"
+        },
+        "exportRequestUuid": {
+          "description": "The unique identifier of the export request that triggered the resource request",
           "type": "string",
           "format": "uuid"
         },
@@ -53,6 +58,7 @@
       },
       "required": [
         "uuid",
+        "exportRequestUuid",
         "application",
         "format",
         "resource",

--- a/schemas/events/v1/events.json
+++ b/schemas/events/v1/events.json
@@ -173,10 +173,10 @@
     {
       "properties": {
         "dataschema": {
-          "const": "https://console.redhat.com/api/schemas/apps/export-service/v1/export-request.json"
+          "const": "https://console.redhat.com/api/schemas/apps/export-service/v1/resource-request.json"
         },
         "data": {
-          "$ref": "../../apps/export-service/v1/export-request.json"
+          "$ref": "../../apps/export-service/v1/resource-request.json"
         }
       },
       "required": [


### PR DESCRIPTION
After talking to Cody from the Export Service, we have agreed that what applications receive are actually resource requests and not export requests.

An export request is generated by the user and is received by the export service, which then sends multiple resource requests to the Kafka channel, which in turn are picked up by the corresponding applications. Then, the export service is responsible for gathering all the responses from the applications and building a proper response to that export request.

Therefore, technically speaking, the applications just receive resource requests associated to an export request.

/cc @CodyWMitchell 

## Links

[[RHCLOUD-26048]](https://issues.redhat.com/browse/RHCLOUD-26048)